### PR TITLE
feat: Port workflow to custom vips-based tools

### DIFF
--- a/.tests/integration/test_workflow.py
+++ b/.tests/integration/test_workflow.py
@@ -38,11 +38,10 @@ def create_config(repository_path: Path, *image_paths: Iterable[Path]) -> Mappin
                      'public': 'repo.pub' },
         'output': {
             'format': 'ome-tiff',
-            'compression': "JPEG",
+            'compression': "jpeg",
             'quality': 90,
-            'tile_height': 4096,
-            'tile_width': 4096,
-            'max_cached_tiles': 256,
+            'tile_size': 512,
+            'thumbnail_width': 2048,
         }
     }
     return config
@@ -105,8 +104,10 @@ def test_workflow(empty_repository, mirax_1_zip):
 
         tiff_files = list((scratch_path / 'tiffs').rglob('*.tiff'))
         assert len(tiff_files) == 1
+        thumbnail_files = list((scratch_path / 'tiffs').rglob('*_thumb.jpg'))
+        assert len(thumbnail_files) == 1
         c4gh_files = list((scratch_path / 'c4gh').rglob('*.c4gh'))
-        assert len(c4gh_files) == 1
+        assert len(c4gh_files) == 2
         tiff_checksums = scratch_path / 'tiffs' / 'tiff_checksums'
         assert tiff_checksums.exists()
         with open(tiff_checksums) as f:

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -13,8 +13,7 @@ keypair:
 
 output:
   format: ome-tiff
-  compression: "JPEG-2000 Lossy"
-  quality: 0.5 # at the moment only has an effect for JPEG-2000 Lossy
-  tile_height: 4096
-  tile_width: 4096
-  max_cached_tiles: 256
+  compression: "jpeg"
+  quality: 90
+  tile_size: 512
+  thumbnail_width: 1024

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -12,10 +12,16 @@ min_version("6.5.0")
 
 
 # Run as:
-# snakemake --snakefile ./img-convert.smk --profile ./profile --configfile zenbanc_config.yml --use-singularity --cores --verbose
+# snakemake --snakefile ./img-convert.smk --profile ./profile --configfile zenbanc_config.yml --use-singularity --cores
 #
 # The configuration must specify the input and output directory trees as
 # `img_directory` and `output_storage`
+
+
+# Default container for rules
+container: "docker://ilveroluca/crypt4gh:1.5"
+
+
 
 ##### Load rules #####
 
@@ -31,24 +37,31 @@ include: "rules/encryption.smk"
 
 configure_environment()
 
+
+##### Glob input ####
+
 source_slides = glob_source_paths()
 log(len(source_slides), "source slides are: ", [ str(s) for s in source_slides ])
 
 
-##### Rules #####
 
+###### Main target rules ##########
 
 rule all_encrypted_tiffs:
     input:
-        encrypted_tiffs =  \
+        encrypted_tiffs = \
             [ Path("c4gh") / s.with_suffix('.ome.tiff' + new_suffix)
                 for s in source_slides for new_suffix in ('.c4gh', '.c4gh.sha') ],
+        encrypted_thumbnails = \
+            [ Path("c4gh") / f"{s.with_suffix('')}_thumb.jpg.c4gh"
+                for s in source_slides ],
         checksums = "tiffs/tiff_checksums",
 
 
 rule all_tiffs:
     input:
         tiffs = [ Path("tiffs") / s.with_suffix('.ome.tiff') for s in source_slides ],
+        thumbnails = [ Path("tiffs") / f"{s.with_suffix('')}_thumb.jpg" for s in source_slides ],
         checksums = "tiffs/tiff_checksums",
 
 
@@ -58,11 +71,9 @@ rule all_tiff_checksums:
     output:
         "tiffs/tiff_checksums"
     log:
-        "tiffs/tiff_checksums.log"
+        "logs/tiff_checksums.log"
     resources:
         mem_mb = 512
-    container:
-        "docker://ilveroluca/raw2ometiff:0.3.0"
     shell:
         """
         cat {input:q} | sort > {output:q} 2> {log:q}

--- a/workflow/rules/checksumming.smk
+++ b/workflow/rules/checksumming.smk
@@ -1,19 +1,17 @@
 
-rule compute_tiff_checksum:
+rule compute_file_checksum:
     input:
         tiff = "tiffs/{slide}.tiff"
     output:
         chksum = "tiffs/{slide}.tiff.sha"
     log:
-        "tiffs/{slide}.tiff.sha.log"
+        "logs/compute_file_checksum/{slide}.tiff.sha.log"
     benchmark:
-        "tiffs/{slide}.tiff.sha.bench"
+        "bench/compute_file_checksum/{slide}.tiff.sha.bench"
     params:
         checksum_alg = 256
     resources:
         mem_mb = 64
-    container:
-        "docker://ilveroluca/raw2ometiff:0.3.0"
     shell:
         """
         sha{params.checksum_alg}sum {input:q} > {output:q} 2> {log:q}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,9 +1,6 @@
 
-import atexit
 import os
-import shutil
 import sys
-import tempfile
 
 from pathlib import Path
 from typing import Iterable, Union
@@ -29,39 +26,19 @@ def get_repository_path() -> Path:
     return Path(config['repository']['path']).resolve()
 
 
-def delete_temp_directory(tmp_dir: Union[str, Path]) -> None:
-    log("Deleting temporary directory", tmp_dir)
-    shutil.rmtree(tmp_dir, ignore_errors=True)
-
-
-def setup_tmp_dir() -> None:
-    """
-    Creates a temporary directory for the workflow run.
-    """
-    tmp_dir = tempfile.mkdtemp(prefix='img-convert-wf', dir=os.getcwd())
-    log("Created temporary directory", tmp_dir)
-    os.environ['TMPDIR'] = tmp_dir
-    atexit.register(delete_temp_directory, tmp_dir)
-
-
-def get_tmp_dir() -> str:
-    """
-    Get temporary directory created within working directory.
-    """
-    return os.environ['TMPDIR']
-
-
 def glob_source_paths() -> Iterable[Path]:
-    base_dir = str(get_repository_path())
+    base_dir = get_repository_path()
     source_paths = [ Path(p) for p in config['sources']['items'] ]
     if any(p.is_absolute() for p in source_paths):
         raise ValueError("Source paths must be relative to repository.path (absolute paths found).")
     # glob any directories for files that end with any of the Extensions
     try:
-        cwd = os.getcwd()
+        cwd = Path.cwd()
         os.chdir(base_dir)
+        # We glob with os.walk rather than Path.rglob to catch any of the supported
+        # in a single directory traversal (with rglob we can only scan for one extension)
         source_files = \
-            [ Path(os.path.join(root, slide))
+            [ Path(root, slide)
                 for p in source_paths if p.is_dir()
                 for root, _, files in os.walk(p)
                 for slide in files if any(slide.endswith(ext) for ext in Extensions) ] + \
@@ -86,8 +63,6 @@ def gen_rule_input_path(wildcard):
 
 ###### Environment configuration functions ######
 def configure_environment():
-    setup_tmp_dir()
-
     shell.prefix("set -o pipefail; ")
 
     if workflow.use_singularity:
@@ -106,5 +81,4 @@ def configure_environment():
             # Use --cleanenv to work around singularity exec overriding env
             # vars from docker image with host values (https://github.com/sylabs/singularity/issues/533)
             " --cleanenv",
-            f" --bind {repository}:{repository}:{mount_options}",
-            f" --env TMPDIR={get_tmp_dir()}"])
+            f" --bind {repository}:{repository}:{mount_options}"])

--- a/workflow/rules/encryption.smk
+++ b/workflow/rules/encryption.smk
@@ -1,13 +1,13 @@
-rule crypt_tiff:
+rule crypt_file:
     input:
-        tiff = "tiffs/{slide}.ome.tiff"
+        tiff = "tiffs/{slide}"
     output:
-        crypt = protected("c4gh/{slide}.ome.tiff.c4gh"),
-        checksum = "c4gh/{slide}.ome.tiff.c4gh.sha"
+        crypt = protected("c4gh/{slide}.c4gh"),
+        checksum = "c4gh/{slide}.c4gh.sha"
     log:
-        "c4gh/{slide}.log"
+        "logs/crypt_file/{slide}.log"
     benchmark:
-        "c4gh/{slide}.bench"
+        "bench/crypt_file/{slide}.bench"
     params:
         checksum_alg = 256,
         private_key = lambda _: config['keypair']['private'],

--- a/workflow/rules/img_conversion.smk
+++ b/workflow/rules/img_conversion.smk
@@ -1,71 +1,55 @@
 
-rule bioformats_to_raw:
+rule slide_to_ometiff:
     input:
         lambda wildcard: gen_rule_input_path(wildcard)
     output:
-        directory(temp("raw_slides/{slide}.raw"))
+        protected("tiffs/{slide}.ome.tiff")
     log:
-        "raw_slides/{slide}.log"
+        "logs/slide_to_ometiff/{slide}.log"
     benchmark:
-        "raw_slides/{slide}.bench"
+        "bench/slide_to_ometiff/{slide}.bench"
     params:
-        log_level = config['log_level'],
-        max_cached_tiles = config.get('tiff', {}).get('max_cached_tiles', 64),
-        memo_directory = lambda _: get_tmp_dir(),
-        tile_height = config['output']['tile_height'],
-        tile_width = config['output']['tile_width'],
-        workers = lambda _, threads: round(1.5 * threads),
+        compression = config['output']['compression'],
+        quality = config['output']['quality'],
+        tile_size = config['output']['tile_size'],
     container:
-        "docker://ilveroluca/bioformats2raw:0.3.1"
+        "docker://ilveroluca/fair-crcc-vips:0.1.0"
     resources:
-        mem_mb = 5000,
-        tmpdir = lambda _: get_tmp_dir()
+        mem_mb = 2000,
     threads:
-        4
+        2
     shell:
         """
         mkdir -p $(dirname {output:q}) &&
-        bioformats2raw \
-            --log-level={params.log_level} \
-            --max_workers={params.workers} \
-            --tile_height={params.tile_height} \
-            --tile_width={params.tile_width} \
-            --memo-directory={params.memo_directory} \
-            --max_cached_tiles={params.max_cached_tiles} \
+        slide_to_ometiff \
+            --compression={params.compression} \
+            --quality={params.quality} \
+            --tile-size={params.tile_size} \
             {input:q} {output:q} &> {log:q}
         """
 
 
-rule raw_to_ometiff:
-    priority: 10  # higher than other rules
+rule slide_to_thumbnail:
     input:
-        "raw_slides/{slide}.raw"
+        lambda wildcard: gen_rule_input_path(wildcard)
     output:
-        protected("tiffs/{slide}.ome.tiff")
+        protected("tiffs/{slide}_thumb.jpg")
     log:
-        "tiffs/{slide}.log"
+        "logs/slide_to_thumbnail/{slide}_thumb.log"
     benchmark:
-        "tiffs/{slide}.bench"
+        "bench/slide_to_thumbnail/{slide}_thumb.bench"
     params:
-        compression = config['output']['compression'],
-        quality = config['output']['quality'],
-        workers = lambda _, threads: threads,
-        log_level = config['log_level']
-    priority: 10
+        width = config['output']['thumbnail_width']
     container:
-        "docker://ilveroluca/raw2ometiff:0.3.0"
+        "docker://ilveroluca/fair-crcc-vips:0.1.0"
     resources:
-        mem_mb = 3000,
-        tmpdir = lambda _: get_tmp_dir()
+        mem_mb = 2000,
     threads:
-        4
+        1
     shell:
         """
         mkdir -p $(dirname {output:q}) &&
-        raw2ometiff \
-            --compression={params.compression:q} \
-            --quality={params.quality} \
-            --log-level={params.log_level} \
-            --max_workers={params.workers} \
+        slide_to_thumbnail \
+            --width {params.width} \
             {input:q} {output:q} &> {log:q}
         """

--- a/workflow/schemas/config.schema.yml
+++ b/workflow/schemas/config.schema.yml
@@ -18,7 +18,8 @@ properties:
         items:
           type: string
           description: >
-            Path to source files or directory. Directories will be globbed.
+            Path to source files or directory. Directories will be globbed
+            for files ending with any of the supported Extensions.
             Paths must be relative to repository path.
     required:
     - items
@@ -49,27 +50,26 @@ properties:
         type: string
         description: compression format to be applied by raw2ometiff
         enum:
-        - "Uncompressed"
-        - "LZW"
-        - "JPEG-2000"
-        - "JPEG-2000 Lossy"
-        - "JPEG"
-        - "zlib"
+        - none
+        - ccittfax4
+        - deflate
+        - jp2k
+        - jpeg
+        - lzw
+        - packbits
+        - webp
+        - zstd
       quality:
         type: number
         description: Quality parameter for raw2ometiff.
-      tile_height:
+      tile_size:
         type: integer
         minimum: 1
-        default: 1024
-      tile_width:
-        type: integer
-        minimum: 1
-        default: 1024
-      max_cached_tiles:
-        type: integer
-        minimum: 0
         default: 256
+      thumbnail_width:
+        type: integer
+        minimum: 1
+        default: 1024
     required:
     - format
     - compression
@@ -92,4 +92,3 @@ required:
 - sources
 - keypair
 - output
-


### PR DESCRIPTION
This PR ports the workflow from the [glencoe approach](https://www.glencoesoftware.com/blog/2019/12/09/converting-whole-slide-images-to-OME-TIFF.html) with bioformats2raw and raw2ometiff to a conversion with a [custom tool](https://github.com/crs4/fair-crcc) we implemented with pyvips.

The PR also adds thumbnail generation.  The thumbnail is generated from the original pyramidal image, so it's fast since it doesn't need to do much rescaling.