### PR TITLE
Fix/pin tabulate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,31 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        snakemake-version: ["6.12.3"]
+        snakemake-version: ["7.15.2", "6.15.5"]
+        python-version: ["3.10"]
+        singularity-version: ["3.10.3"]
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install singularity
       run: |
         curl --output /tmp/singularity-ce.deb --location \
-            https://github.com/sylabs/singularity/releases/download/v3.9.4/singularity-ce_3.9.4-focal_amd64.deb && \
+            "https://github.com/sylabs/singularity/releases/download/v${{ matrix.singularity-version }}/singularity-ce_${{ matrix.singularity-version }}-focal_amd64.deb" && \
         sudo apt update -y && \
         sudo apt install -y /tmp/singularity-ce.deb
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
         mamba-version: "*"
         channels: bioconda,conda-forge,defaults
         channel-priority: true
         miniforge-variant: "Mambaforge"
-        miniforge-version: "4.11.0-0"
+        miniforge-version: "4.14.0-0"
         use-mamba: true
 
     - name: mamba install dependencies
       shell: bash -l {0}
+      # LP: as of 2022-10-27 we have to pin the tabulate package to a version < 0.9
+      # to work around a snakemake issue #1892.
       run: |
         mamba install \
+          'tabulate<0.9' \
           snakemake-minimal==${{ matrix.snakemake-version }} \
           pytest
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -12,10 +12,8 @@ min_version("6.5.0")
 
 
 # Run as:
-# snakemake --snakefile ./img-convert.smk --profile ./profile --configfile zenbanc_config.yml --use-singularity --cores
+# snakemake --snakefile ./Snakefile --profile ./profile --configfile zenbanc_config.yml --use-singularity --cores
 #
-# The configuration must specify the input and output directory trees as
-# `img_directory` and `output_storage`
 
 
 # Default container for rules


### PR DESCRIPTION
This PR restricts snakemake's `tabulate` dependency to version <0.9 to avoid an API change which breaks snakemake.